### PR TITLE
Add info about repo history

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,9 @@ In this repository, for BumbleBee you will find:
 This repository was constructed by [Sujith Katakam](https://github.com/sujithktkm) under the supervision of [Emerson Murphy-Hill](https://github.com/CaptainEmerson). Thanks to [Felienne Hermans](http://www.felienne.com/) and **Efthimia Aivaloglou** for their help in establishing this repository. And thanks to the original authors [Felienne Hermans](http://www.felienne.com/) and Danny Dig of the paper we referenced for this repos. 
 
 Additional Information:
+-----------------------
+Tool inforamtion:
 The [executable tool](https://github.com/SoftwareEngineeringToolDemos/FSE-2014-BumbleBee/blob/master/BumbleBee.zip) in our repository is a version for EXCEL 2010. It  is an installer for Excel 2010. By adding your own transformations to the worksheet ‘Transformations’ and hitting ‘Initialize’ you can create your own rules and play around with them. (quoted from authors' website)
+
+Repository (Program) history:
+This tool did not originally be distributed through Github or any other open source platform. It opened to download in [author's Blog](http://www.felienne.com/archives/2964). So the repository deos not maintain previous history.


### PR DESCRIPTION
Since the tool was not in any other open source website (come from author's blog only). I added this information to explain about the repository history.
